### PR TITLE
Add DockerMock class

### DIFF
--- a/src/main/groovy/com/ableton/DockerMock.groovy
+++ b/src/main/groovy/com/ableton/DockerMock.groovy
@@ -1,0 +1,79 @@
+package com.ableton
+
+
+@SuppressWarnings('EmptyMethod')
+@SuppressWarnings('UnusedMethodParameter')
+class DockerMock {
+  static class Container {
+    String id
+
+    Container(String id = 'mock-container') {
+      this.id = id
+    }
+
+    def port() {
+      // TODO: Is this return type correct?
+      return '1234'
+    }
+
+    def stop() {}
+  }
+
+  static class Image {
+    String id
+    String tagname
+
+    Image(String id) {
+      this.id = id
+      this.tagname = 'latest'
+    }
+
+    def imageName() {
+      return id
+    }
+
+    def inside(String args = '', Closure body) {
+      return body(new Container())
+    }
+
+    def pull() {}
+
+    def push(String tagname = '') {
+      if (tagname) {
+        tag(tagname)
+      }
+    }
+
+    def run(String args = '', String command = '') {
+      return new Container()
+    }
+
+    def tag(String tagname = '') {
+      this.tagname = tagname
+    }
+
+    def withRun(String args = '', String command = '', Closure body) {
+      return body(new Container())
+    }
+  }
+
+  static build(String image, String args = '') {
+    return new Image(image)
+  }
+
+  static image(String id) {
+    return new Image(id)
+  }
+
+  static withRegistry(String url, String credentialsId = '', Closure body) {
+    return body()
+  }
+
+  static withServer(String uri, String credentialsId = '', Closure body) {
+    return body()
+  }
+
+  static withTool(String toolName, Closure body) {
+    return body()
+  }
+}

--- a/src/main/groovy/com/ableton/JenkinsMocks.groovy
+++ b/src/main/groovy/com/ableton/JenkinsMocks.groovy
@@ -78,7 +78,8 @@ class JenkinsMocks {
 
     if (returnStdout) {
       return output.stdout
-    } else if (returnStatus) {
+    }
+    if (returnStatus) {
       return output.exitValue
     }
 

--- a/src/main/groovy/com/ableton/JenkinsMocks.groovy
+++ b/src/main/groovy/com/ableton/JenkinsMocks.groovy
@@ -80,8 +80,8 @@ class JenkinsMocks {
       return output.stdout
     } else if (returnStatus) {
       return output.exitValue
-    } else {
-      return output.exitValue == 0
     }
+
+    return output.exitValue == 0
   }
 }

--- a/src/main/groovy/com/ableton/JenkinsMocks.groovy
+++ b/src/main/groovy/com/ableton/JenkinsMocks.groovy
@@ -69,7 +69,7 @@ class JenkinsMocks {
 
     MockScriptOutput output = mockScriptOutputs[script]
     if (!output) {
-      throw new IllegalArgumentException("No mock output configured for script call " +
+      throw new IllegalArgumentException('No mock output configured for script call ' +
         "'${script}', did you forget to call JenkinsMocks.addShMock()?")
     }
     if (!returnStdout) {

--- a/src/test/groovy/com/ableton/DockerMockTest.groovy
+++ b/src/test/groovy/com/ableton/DockerMockTest.groovy
@@ -1,0 +1,30 @@
+package com.ableton
+
+import com.lesfurets.jenkins.unit.BasePipelineTest
+import org.junit.Before
+import org.junit.Test
+
+
+/**
+ * Test the DockerMock class
+ *
+ * It would be a bit redundant to write regular unit tests for DockerMock, because most of
+ * the methods are empty or void. So instead this test class loads a Jenkins pipeline file
+ * which exercises all of the methods of the docker singleton.
+ */
+class DockerMockTest extends BasePipelineTest {
+  def script
+
+  @Before
+  @Override
+  void setUp() {
+    super.setUp()
+    this.script = loadScript('src/test/resources/DockerPipeline.groovy')
+    this.script.docker = new DockerMock()
+  }
+
+  @Test
+  void executePipeline() throws Exception {
+    script.execute()
+  }
+}

--- a/src/test/groovy/com/ableton/JenkinsMocksTest.groovy
+++ b/src/test/groovy/com/ableton/JenkinsMocksTest.groovy
@@ -13,12 +13,6 @@ import org.junit.Test
  * Tests for the JenkinsMocks class.
  */
 class JenkinsMocksTest extends BasePipelineTest {
-  @Override
-  @Before
-  void setUp() {
-    super.setUp()
-  }
-
   @Test
   void echo() throws Exception {
     // Just a sanity check test to make sure nothing throws

--- a/src/test/groovy/com/ableton/JenkinsMocksTest.groovy
+++ b/src/test/groovy/com/ableton/JenkinsMocksTest.groovy
@@ -1,13 +1,12 @@
 package com.ableton
 
-import com.lesfurets.jenkins.unit.BasePipelineTest
-import org.junit.Before
-import org.junit.Test
-
 import static org.junit.Assert.assertEquals
 import static org.junit.Assert.assertFalse
 import static org.junit.Assert.assertNotNull
 import static org.junit.Assert.assertTrue
+
+import com.lesfurets.jenkins.unit.BasePipelineTest
+import org.junit.Test
 
 
 /**

--- a/src/test/resources/DockerPipeline.groovy
+++ b/src/test/resources/DockerPipeline.groovy
@@ -1,0 +1,79 @@
+def execute() {
+  node {
+    def testImageName = 'test'
+
+    stage('Test docker.build()') {
+      def image = docker.build(testImageName)
+      assert image.id == testImageName
+    }
+
+    stage('Test docker.image()') {
+      def image = docker.image(testImageName)
+      assert image.id == testImageName
+    }
+
+    stage('Test docker.withRegistry') {
+      docker.withRegistry('test.registry', 'fake-credentials') {
+        def image = docker.image(testImageName)
+        // TODO: Should the registry URL be prepended to the image name here?
+        assert image.id == testImageName
+      }
+    }
+
+    stage('Test docker.withServer()') {
+      docker.withServer('test.server', 'fake-credentials') {
+        def image = docker.image(testImageName)
+        assert image.id == testImageName
+      }
+    }
+
+    stage('Test docker.withTool()') {
+      docker.withTool('test-docker') {
+        def image = docker.image(testImageName)
+        assert image.id == testImageName
+      }
+    }
+
+    stage('Test docker.image.imageName()') {
+      def image = docker.image(testImageName)
+      assert image.imageName() == testImageName
+    }
+
+    stage('Test docker.image.inside()') {
+      def image = docker.image(testImageName)
+      image.inside {
+        assert image.id == testImageName
+      }
+    }
+
+    stage('Test docker.image.pull()') {
+      docker.image(testImageName).pull()
+    }
+
+    stage('Test docker.image.push()') {
+      def image = docker.image(testImageName)
+      image.push('test-tag')
+      assert image.tagname == 'test-tag'
+    }
+
+    stage('Test docker.image.run()') {
+      def container = docker.image(testImageName).run()
+      container.stop()
+    }
+
+    stage('Test docker.image.tag()') {
+      def image = docker.image(testImageName)
+      image.tag('test')
+      assert image.tagname == 'test'
+    }
+
+    stage('Test docker.image.withRun()') {
+      def image = docker.image(testImageName)
+      image.withRun {
+        assert image.id == testImageName
+      }
+    }
+  }
+}
+
+return this


### PR DESCRIPTION
This class makes it possible to mock the `docker` singleton, which will make it possible for us to test much more of our pipeline code. Also this PR includes some groovylint cleanups, since it turns out that RTB was not configured to automatically build this repo on PR/push events.

ptal @AbletonDevTools/gotham-city, thanks!