### PR TITLE
Add mock for retry() function

### DIFF
--- a/src/main/groovy/com/ableton/JenkinsMocks.groovy
+++ b/src/main/groovy/com/ableton/JenkinsMocks.groovy
@@ -23,6 +23,22 @@ class JenkinsMocks {
     return System.properties[args?.tmp ? 'java.io.tmpdir' : 'user.dir']
   }
 
+  static Closure retry = { count, body ->
+    Exception lastError = null
+    while (count-- > 0) {
+      try {
+        body()
+        lastError = null
+      } catch (error) {
+        lastError = error
+      }
+    }
+
+    if (lastError) {
+      throw lastError
+    }
+  }
+
   /**
    * Simple container for holding mock script output.
    * @see JenkinsMocks#addShMock

--- a/src/test/groovy/com/ableton/JenkinsMocksTest.groovy
+++ b/src/test/groovy/com/ableton/JenkinsMocksTest.groovy
@@ -53,6 +53,50 @@ class JenkinsMocksTest extends BasePipelineTest {
   }
 
   @Test
+  void retry() throws Exception {
+    def bodyExecuted = false
+    JenkinsMocks.retry(2) {
+      bodyExecuted = true
+    }
+    assertTrue(bodyExecuted)
+  }
+
+  @Test
+  @SuppressWarnings('ThrowException')
+  void retryFailOnce() throws Exception {
+    def count = 2
+    def exceptionThrown = false
+    def bodyExecuted = false
+    JenkinsMocks.retry(2) {
+      if (count-- == 2) {
+        exceptionThrown = true
+        throw new Exception()
+      }
+      bodyExecuted = true
+    }
+    assertTrue(exceptionThrown)
+    assertTrue(bodyExecuted)
+  }
+
+  @Test
+  @SuppressWarnings('ThrowException')
+  void retryFail() throws Exception {
+    def failed = false
+    def count = 2
+    try {
+      JenkinsMocks.retry(2) {
+        count--
+        throw new Exception('test')
+      }
+    } catch (error) {
+      assertEquals('test', error.message)
+      failed = true
+    }
+    assertEquals(0, count)
+    assertTrue(failed)
+  }
+
+  @Test
   void sh() throws Exception {
     JenkinsMocks.addShMock('pwd', '/foo/bar', 0)
     assertTrue(JenkinsMocks.sh('pwd'))


### PR DESCRIPTION
In case anyone was wondering, both this PR and the last one (adding a mock for `error`) will be used in the upcoming unit tests for postgres-pipeline-utils. ptal @AbletonDevTools/gotham-city, thanks!