### PR TITLE
Fix behavior of sh mock to match Jenkins

### DIFF
--- a/src/main/groovy/com/ableton/JenkinsMocks.groovy
+++ b/src/main/groovy/com/ableton/JenkinsMocks.groovy
@@ -106,7 +106,5 @@ class JenkinsMocks {
     if (output.exitValue != 0) {
       throw new Exception('Script returned error code: ' + output.exitValue)
     }
-
-    return output.exitValue == 0
   }
 }

--- a/src/main/groovy/com/ableton/JenkinsMocks.groovy
+++ b/src/main/groovy/com/ableton/JenkinsMocks.groovy
@@ -103,6 +103,9 @@ class JenkinsMocks {
     if (returnStatus) {
       return output.exitValue
     }
+    if (output.exitValue != 0) {
+      throw new Exception('Script returned error code: ' + output.exitValue)
+    }
 
     return output.exitValue == 0
   }

--- a/src/test/groovy/com/ableton/JenkinsMocksTest.groovy
+++ b/src/test/groovy/com/ableton/JenkinsMocksTest.groovy
@@ -106,8 +106,15 @@ class JenkinsMocksTest extends BasePipelineTest {
 
   @Test
   void shWithScriptFailure() throws Exception {
-    JenkinsMocks.addShMock('evil', '/foo/bar', 666)
-    assertFalse(JenkinsMocks.sh('evil'))
+    def exceptionThrown = false
+    try {
+      JenkinsMocks.addShMock('evil', '/foo/bar', 666)
+      JenkinsMocks.sh('evil')
+    } catch (error) {
+      exceptionThrown = true
+      assertNotNull(error)
+    }
+    assertTrue(exceptionThrown)
   }
 
   @Test

--- a/src/test/groovy/com/ableton/JenkinsMocksTest.groovy
+++ b/src/test/groovy/com/ableton/JenkinsMocksTest.groovy
@@ -21,12 +21,14 @@ class JenkinsMocksTest extends BasePipelineTest {
 
   @Test
   void error() throws Exception {
+    def exceptionThrown = false
     try {
       JenkinsMocks.error('test')
-      fail('Expected exception, but none was thrown')
     } catch (error) {
+      exceptionThrown = true
       assertEquals('test', error.message)
     }
+    assertTrue(exceptionThrown)
   }
 
   @Test
@@ -128,21 +130,25 @@ class JenkinsMocksTest extends BasePipelineTest {
 
   @Test
   void shWithoutMockScript() throws Exception {
+    def exceptionThrown = false
     try {
       JenkinsMocks.sh('invalid')
-      fail('Expected exception, but none was thrown')
     } catch (IllegalArgumentException error) {
+      exceptionThrown = true
       assertNotNull(error)
     }
+    assertTrue(exceptionThrown)
   }
 
   @Test
   void shWithBothStatusAndStdout() throws Exception {
+    def exceptionThrown = false
     try {
       JenkinsMocks.sh(returnStatus: true, returnStdout: true, script: 'invalid')
-      fail('Expected exception, but none was thrown')
     } catch (IllegalArgumentException error) {
+      exceptionThrown = true
       assertNotNull(error)
     }
+    assertTrue(exceptionThrown)
   }
 }

--- a/src/test/groovy/com/ableton/JenkinsMocksTest.groovy
+++ b/src/test/groovy/com/ableton/JenkinsMocksTest.groovy
@@ -3,6 +3,7 @@ package com.ableton
 import static org.junit.Assert.assertEquals
 import static org.junit.Assert.assertFalse
 import static org.junit.Assert.assertNotNull
+import static org.junit.Assert.assertNull
 import static org.junit.Assert.assertTrue
 
 import com.lesfurets.jenkins.unit.BasePipelineTest
@@ -101,7 +102,7 @@ class JenkinsMocksTest extends BasePipelineTest {
   @Test
   void sh() throws Exception {
     JenkinsMocks.addShMock('pwd', '/foo/bar', 0)
-    assertTrue(JenkinsMocks.sh('pwd'))
+    assertNull(JenkinsMocks.sh('pwd'))
   }
 
   @Test


### PR DESCRIPTION
First of all, there is a really dumb bug in these tests, as well as in some of our other pipeline test code, which looks like this:

```groovy
@Test
void something() throws Exception {
  try {
    shouldFail()
    fail('Expected exception, but none was thrown')
  } catch (error) {
    assertNotNull(error)
  }
}
```

So the stupidity here is that `Assert.fail` (which comes from JUnit) is throwing an exception, which we catch and assert in the below `catch` block. This means that if `shouldFail()` does not fail, we'd never know about it because JUnit throws us another exception anyways. 😅

This PR fixes that error, and also corrects the behavior of our `sh` mock to behave like Jenkins. I did a number of experiments in the Jenkins sandbox to confirm how `sh` handles script failures (returning a non-zero code, that is), which should be like so:

- If `returnStdout` is specified, throws an exception
- If `returnStatus` is specified, then it should return the status code
- If neither `returnStatus` nor `returnStdout` are specified, then it should throw an exception

Also, if neither `returnStatus` nor `returnStdout` are specified, then `sh` returns `null`, not `0`.

ptal @AbletonDevTools/gotham-city, thanks!