### PR TITLE
Remove unused import

### DIFF
--- a/src/test/groovy/com/ableton/JenkinsMocksTest.groovy
+++ b/src/test/groovy/com/ableton/JenkinsMocksTest.groovy
@@ -1,7 +1,6 @@
 package com.ableton
 
 import static org.junit.Assert.assertEquals
-import static org.junit.Assert.assertNotNull
 import static org.junit.Assert.assertNull
 import static org.junit.Assert.assertTrue
 


### PR DESCRIPTION
This causes a CodeNarc failure, I'm not sure why it wasn't caught
earlier.

FYI @AbletonDevTools/gotham-city 