### PR TITLE
Add clearStaticData function to call in tearDown

### DIFF
--- a/src/main/groovy/com/ableton/JenkinsMocks.groovy
+++ b/src/main/groovy/com/ableton/JenkinsMocks.groovy
@@ -6,6 +6,17 @@ package com.ableton
  * with the JenkinsPipelineUnit library.
  */
 class JenkinsMocks {
+  /**
+   * Clears static data used by some closures in this class. If you use any of the
+   * following functions, you should call this function in your tearDown method:
+   * <ul>
+   *   <li>{@link JenkinsMocks#addShMock}</li>
+   * </ul>
+   */
+  static void clearStaticData() {
+    mockScriptOutputs.clear()
+  }
+
   static Closure dir = { String path, Closure body ->
     body()
   }

--- a/src/test/groovy/com/ableton/JenkinsMocksTest.groovy
+++ b/src/test/groovy/com/ableton/JenkinsMocksTest.groovy
@@ -5,6 +5,7 @@ import static org.junit.Assert.assertNull
 import static org.junit.Assert.assertTrue
 
 import com.lesfurets.jenkins.unit.BasePipelineTest
+import org.junit.After
 import org.junit.Test
 
 
@@ -12,6 +13,21 @@ import org.junit.Test
  * Tests for the JenkinsMocks class.
  */
 class JenkinsMocksTest extends BasePipelineTest {
+  @After
+  void tearDown() throws Exception {
+    JenkinsMocks.clearStaticData()
+  }
+
+  @Test
+  void clearStaticData() throws Exception {
+    JenkinsMocks.addShMock('test', '', 0)
+    assertEquals(1, JenkinsMocks.mockScriptOutputs.size())
+
+    JenkinsMocks.clearStaticData()
+
+    assertEquals(0, JenkinsMocks.mockScriptOutputs.size())
+  }
+
   @Test
   void echo() throws Exception {
     // Just a sanity check test to make sure nothing throws


### PR DESCRIPTION
Because JUnit uses a single process to run all tests, and not one
process per test (for obvious reasons), static data belonging to
classes will not be cleared out between test runs. This commit adds a
new clearStaticData() function that should be called in the unit
test's tearDown().

We've been lucky that our tests use addShMock in such a manner that
does not trigger incorrect test results due to static data being
preserved between tests.

ptal @AbletonDevTools/gotham-city, thanks!