### PR TITLE
Add mock for readFile pipeline step

### DIFF
--- a/src/main/groovy/com/ableton/JenkinsMocks.groovy
+++ b/src/main/groovy/com/ableton/JenkinsMocks.groovy
@@ -17,6 +17,7 @@ class JenkinsMocks {
    * </ul>
    */
   static void clearStaticData() {
+    mockReadFileOutputs.clear()
     mockScriptOutputs.clear()
     catchErrorParent = null
     catchErrorUpdateBuildStatus = null
@@ -68,6 +69,28 @@ class JenkinsMocks {
 
   static Closure pwd = { args = [:] ->
     return System.properties[args?.tmp ? 'java.io.tmpdir' : 'user.dir']
+  }
+
+  static Map<String, String> mockReadFileOutputs = [:]
+
+  static void addReadFileMock(String file, String contents) {
+    mockReadFileOutputs[file] = contents
+  }
+
+  static Closure readFile = { args ->
+    String file = null
+    if (args instanceof String || args instanceof GString) {
+      file = args
+    } else if (args instanceof Map) {
+      file = args['file']
+    }
+    assert file
+
+    if (!mockReadFileOutputs.containsKey(file)) {
+      throw new IllegalArgumentException("No mock output configured for '${file}', " +
+        'did you forget to call JenkinsMocks.addReadFileMock()?')
+    }
+    return mockReadFileOutputs[file]
   }
 
   static Closure retry = { count, body ->

--- a/src/test/groovy/com/ableton/JenkinsMocksTest.groovy
+++ b/src/test/groovy/com/ableton/JenkinsMocksTest.groovy
@@ -32,6 +32,8 @@ class JenkinsMocksTest extends BasePipelineTest {
 
   @Test
   void clearStaticData() throws Exception {
+    JenkinsMocks.addReadFileMock('test', 'contents')
+    assertEquals(1, JenkinsMocks.mockReadFileOutputs.size())
     JenkinsMocks.addShMock('test', '', 0)
     assertEquals(1, JenkinsMocks.mockScriptOutputs.size())
     JenkinsMocks.setCatchErrorParent(this)
@@ -40,6 +42,7 @@ class JenkinsMocksTest extends BasePipelineTest {
 
     JenkinsMocks.clearStaticData()
 
+    assertEquals(0, JenkinsMocks.mockReadFileOutputs.size())
     assertEquals(0, JenkinsMocks.mockScriptOutputs.size())
     assertNull(JenkinsMocks.catchErrorParent)
     assertNull(JenkinsMocks.catchErrorUpdateBuildStatus)
@@ -110,6 +113,23 @@ class JenkinsMocksTest extends BasePipelineTest {
     assertEquals(System.properties['java.io.tmpdir'], result)
     File f = new File(result)
     assertTrue(f.exists())
+  }
+
+  @Test
+  void readFile() throws Exception {
+    JenkinsMocks.addReadFileMock('test', 'contents')
+    assertEquals('contents', JenkinsMocks.readFile('test'))
+  }
+
+  @Test
+  void readFileWithMap() throws Exception {
+    JenkinsMocks.addReadFileMock('test', 'contents')
+    assertEquals('contents', JenkinsMocks.readFile(file: 'test'))
+  }
+
+  @Test(expected = IllegalArgumentException)
+  void readFileWithNoMock() throws Exception {
+    JenkinsMocks.readFile('test')
   }
 
   @Test


### PR DESCRIPTION
Like `sh`, this mock also has a helper function to configure the mock
output.

ptal @AbletonDevTools/gotham-city, thanks!