### PR TITLE
waitUntil and addShMockCallback to reroute script commands to callback

### DIFF
--- a/src/main/groovy/com/ableton/JenkinsMocks.groovy
+++ b/src/main/groovy/com/ableton/JenkinsMocks.groovy
@@ -209,6 +209,19 @@ class JenkinsMocks {
     }
   }
 
+  static def waitUntil(int maxTimes, Closure body) {
+      int count = 0
+      while(body() == false){
+          count++
+          if(count > maxTimes){
+              throw new Exception("waitUntil: failed due to could not resolve in ${maxTimes} loops")
+          }
+      }
+  }
+  static def waitUntil = { body ->
+      waitUntil(100, body)
+  }
+
   static Closure sleep = { /* noop */ }
 
   static Closure stash = { /* noop */ }

--- a/src/test/groovy/com/ableton/JenkinsMocksTest.groovy
+++ b/src/test/groovy/com/ableton/JenkinsMocksTest.groovy
@@ -220,4 +220,12 @@ class JenkinsMocksTest extends BasePipelineTest {
   void shWithBothStatusAndStdout() throws Exception {
     JenkinsMocks.sh(returnStatus: true, returnStdout: true, script: 'invalid')
   }
+
+  @Test
+  void shWithCallback() throws Exception {
+    JenkinsMocks.addShMockCallback('python') { script, returnStdout, returnStatus ->
+        return "${script}, returnStdout:${returnStdout}, returnStatus:${returnStatus}".toString()
+    }
+    assertEquals("python script.py, returnStdout:true, returnStatus:false", JenkinsMocks.sh(returnStdout: true, script: 'python script.py'))
+  }
 }

--- a/src/test/groovy/com/ableton/JenkinsMocksTest.groovy
+++ b/src/test/groovy/com/ableton/JenkinsMocksTest.groovy
@@ -228,4 +228,34 @@ class JenkinsMocksTest extends BasePipelineTest {
     }
     assertEquals("python script.py, returnStdout:true, returnStatus:false", JenkinsMocks.sh(returnStdout: true, script: 'python script.py'))
   }
+
+  @Test
+  void waitUntilCalledTwice() throws Exception {
+    int count=0
+    JenkinsMocks.waitUntil {
+       count++
+      if(count >= 2)
+        return true
+      return false
+    }
+    assertEquals(2, count)
+  }
+
+  @Test(expected = Exception)
+  void waitUntilExceedDefaultLimit() throws Exception {
+    JenkinsMocks.waitUntil {
+      return false
+    }
+  }
+
+  @Test(expected = Exception)
+  void waitUntilExceedSetLimit() throws Exception {
+    int count=0
+    JenkinsMocks.waitUntil(5) {
+      count++
+      if(count >= 10)
+          return true
+      return false
+    }
+  }
 }


### PR DESCRIPTION
waitUntil mock and addShMockCallback

sh mock can be extended with callback for sh commands that contains a keyword.
This opens up more chances to implement something specific for some commands, e.g. just reroute some app/tool commands for further handling, logging, mocking, verification etc.