### PR TITLE
Add waitUntil mock, allow addShMock to take a closure

### DIFF
--- a/src/main/groovy/com/ableton/JenkinsMocks.groovy
+++ b/src/main/groovy/com/ableton/JenkinsMocks.groovy
@@ -240,5 +240,19 @@ class JenkinsMocks {
 
   static Closure unstash = { /* noop */ }
 
+  /**
+   * Mock for Jenkins waitUntil step. Unlike the implementation on Jenkins, this mock will
+   * abort after 100 failures, nor does it have exponential backoff between failures.
+   */
+  @SuppressWarnings('ThrowException')
+  static void waitUntil(Closure body) {
+    int count = 100
+    while (!body()) {
+      if (count-- <= 0) {
+        throw new Exception('waitUntil: failed 100 times, refusing to continue')
+      }
+    }
+  }
+
   static Closure writeFile = { /* noop */ }
 }

--- a/src/test/groovy/com/ableton/JenkinsMocksTest.groovy
+++ b/src/test/groovy/com/ableton/JenkinsMocksTest.groovy
@@ -286,4 +286,21 @@ class JenkinsMocksTest extends BasePipelineTest {
   void shWithBothStatusAndStdout() throws Exception {
     JenkinsMocks.sh(returnStatus: true, returnStdout: true, script: 'invalid')
   }
+
+  @Test
+  void waitUntilCalledTwice() throws Exception {
+    int count = 0
+    JenkinsMocks.waitUntil {
+      count++
+      return count == 2
+    }
+    assertEquals(2, count)
+  }
+
+  @Test(expected = Exception)
+  void waitUntilExceedDefaultLimit() throws Exception {
+    JenkinsMocks.waitUntil {
+      return false
+    }
+  }
 }

--- a/src/test/groovy/com/ableton/JenkinsMocksTest.groovy
+++ b/src/test/groovy/com/ableton/JenkinsMocksTest.groovy
@@ -213,6 +213,70 @@ class JenkinsMocksTest extends BasePipelineTest {
     assertEquals(666, JenkinsMocks.sh(returnStatus: true, script: 'evil'))
   }
 
+  @Test
+  void shWithCallback() throws Exception {
+    JenkinsMocks.addShMock('pwd') { script ->
+      return [stdout: '/foo/bar', exitValue: 0]
+    }
+    assertNull(JenkinsMocks.sh('pwd'))
+  }
+
+  @Test(expected = Exception)
+  void shWithCallbackScriptFailure() throws Exception {
+    JenkinsMocks.addShMock('evil') { script ->
+      return [stdout: '/foo/bar', exitValue: 666]
+    }
+    JenkinsMocks.sh('evil')
+  }
+
+  @Test
+  void shWithCallbackStdout() throws Exception {
+    JenkinsMocks.addShMock('pwd') { script ->
+      return [stdout: '/foo/bar', exitValue: 0]
+    }
+    assertEquals('/foo/bar', JenkinsMocks.sh(returnStdout: true, script: 'pwd'))
+  }
+
+  @Test
+  void shWithCallbackReturnCode() throws Exception {
+    JenkinsMocks.addShMock('pwd') { script ->
+      return [stdout: '/foo/bar', exitValue: 0]
+    }
+    assertEquals(0, JenkinsMocks.sh(returnStatus: true, script: 'pwd'))
+  }
+
+  @Test
+  void shWithCallbackNonZeroReturnCode() throws Exception {
+    JenkinsMocks.addShMock('pwd') { script ->
+      return [stdout: '/foo/bar', exitValue: 666]
+    }
+    assertEquals(666, JenkinsMocks.sh(returnStatus: true, script: 'pwd'))
+  }
+
+  @Test(expected = IllegalArgumentException)
+  void shWithCallbackOutputNotMap() throws Exception {
+    JenkinsMocks.addShMock('pwd') { script ->
+      return 'invalid'
+    }
+    JenkinsMocks.sh(returnStatus: true, script: 'pwd')
+  }
+
+  @Test(expected = IllegalArgumentException)
+  void shWithCallbackNoStdoutKey() throws Exception {
+    JenkinsMocks.addShMock('pwd') { script ->
+      return [exitValue: 666]
+    }
+    JenkinsMocks.sh(returnStatus: true, script: 'pwd')
+  }
+
+  @Test(expected = IllegalArgumentException)
+  void shWithCallbackNoExitValueKey() throws Exception {
+    JenkinsMocks.addShMock('pwd') { script ->
+      return [stdout: '/foo/bar']
+    }
+    JenkinsMocks.sh(returnStatus: true, script: 'pwd')
+  }
+
   @Test(expected = IllegalArgumentException)
   void shWithoutMockScript() throws Exception {
     JenkinsMocks.sh('invalid')

--- a/src/test/groovy/com/ableton/JenkinsMocksTest.groovy
+++ b/src/test/groovy/com/ableton/JenkinsMocksTest.groovy
@@ -14,6 +14,7 @@ import org.junit.Test
 /**
  * Tests for the JenkinsMocks class.
  */
+@SuppressWarnings('MethodCount')
 class JenkinsMocksTest extends BasePipelineTest {
   // The setUp() method in the super class is not annotated with @Before since
   // JenkinsPipelineUnit does not directly depend on the JUnit framework. As such, we need


### PR DESCRIPTION
This PR addresses half of https://github.com/AbletonDevTools/jenkins-pipeline-mocks/pull/19, specifically the addition of the `waitUntil` mock and allowing the `sh` mock to also be a closure which is executed when mock is run. It was decided that #19 should be addressed in two separate PRs, and this PR is the first part of that work.

ping @AbletonDevTools/gotham-city, @keijohyttinen