### PR TITLE
Bump Groovy version to 2.4.12

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ repositories {
 }
 
 dependencies {
-  compile 'org.codehaus.groovy:groovy-all:2.4.10'
+  compile 'org.codehaus.groovy:groovy-all:2.4.12'
 
   testCompile 'junit:junit:4.12'
 


### PR DESCRIPTION
This is the version shipped with Jenkins 2.176.2, which can be derived
by running "println GroovySystem.version" in the script console.

---

ping @AbletonDevTools/gotham-city 