### PR TITLE
Add CODEOWNERS to automatically assign reviewers

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,2 @@
+# Auto-assign a reviewer using Pull Assigner.
+*   @AbletonDevTools/gotham-city


### PR DESCRIPTION
This uses Pull Assigner to automatically assign pull reviewers.

@AbletonDevTools/gotham-city ptal!